### PR TITLE
Authorization Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ class DieAndDumpQuery extends Plugin implements AdaptCollectionQuery, AdaptResou
 
 ##### Plugin Hooks
 
-The available hooks are listed in the ["Hooks" directory](https://github.com/sehrgutesoftware/laravel5-api/tree/master/src/Laravel5_Api/Hooks). In order to use a hook, you simply have to declare that your plugin class `implements` the corresponding interface and then actually implement the appropriate method of that interface. Take a look at source code of the [existing plugins](https://github.com/sehrgutesoftware/laravel5-api/tree/master/src/Laravel5_Api/Plugins) to see how this is done. Each hook interface always contains to exactly one method.
+The available hooks are listed in the ["Hooks" directory](https://github.com/sehrgutesoftware/laravel5-api/tree/master/src/Laravel5_Api/Hooks). In order to use a hook, you simply have to declare that your plugin class `implements` the corresponding interface and then actually implement the appropriate method of that interface. Take a look at source code of the [existing plugins](https://github.com/sehrgutesoftware/laravel5-api/tree/master/src/Laravel5_Api/Plugins) to see how this is done. Each hook interface always contains exactly one method.
 
 ###### Available Hooks
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "require-dev": {
         "phpunit/phpunit": "~5.5",
         "phpspec/phpspec": "~2.1",
-        "laravel/laravel": "~5.3"
+        "laravel/laravel": "~5.3",
+        "mockery/mockery": "^0.9.9"
     },
     "autoload": {
         "psr-4": { "SehrGut\\Laravel5_Api\\": "src/Laravel5_Api" }

--- a/src/Laravel5_Api/Controller.php
+++ b/src/Laravel5_Api/Controller.php
@@ -615,7 +615,7 @@ class Controller extends IlluminateController
      * This is used to receive the model's FQN.
      * Some plugins might need to know which model they are dealing with.
      *
-     * @return String
+     * @return string
      */
     public function getModelNameWithNamespace()
     {

--- a/src/Laravel5_Api/Controller.php
+++ b/src/Laravel5_Api/Controller.php
@@ -613,6 +613,7 @@ class Controller extends IlluminateController
 
     /**
      * This is used to receive the model's FQN.
+     *
      * Some plugins might need to know which model they are dealing with.
      *
      * @return string

--- a/src/Laravel5_Api/Controller.php
+++ b/src/Laravel5_Api/Controller.php
@@ -267,7 +267,6 @@ class Controller extends IlluminateController
      */
     public function show()
     {
-        $this->applyHooks(AuthorizeAction::class, 'show');
         $this->getResource();
         $this->applyHooks(AuthorizeResource::class, 'show');
         $this->formatResource();
@@ -282,7 +281,6 @@ class Controller extends IlluminateController
      */
     public function update()
     {
-        $this->applyHooks(AuthorizeAction::class, 'update');
         $this->getResource();
         $this->applyHooks(AuthorizeResource::class, 'update');
         $this->gatherInput();
@@ -300,7 +298,6 @@ class Controller extends IlluminateController
      */
     public function destroy()
     {
-        $this->applyHooks(AuthorizeAction::class, 'destroy');
         $this->getResource();
         $this->applyHooks(AuthorizeResource::class, 'destroy');
         $this->destroyResource();

--- a/src/Laravel5_Api/Controller.php
+++ b/src/Laravel5_Api/Controller.php
@@ -613,4 +613,15 @@ class Controller extends IlluminateController
     protected function afterConstruct()
     {
     }
+
+    /**
+     * This is used to receive the model's FQN.
+     * Some plugins might need to know which model they are dealing with.
+     *
+     * @return String
+     */
+    public function getModelNameWithNamespace()
+    {
+        return $this->model;
+    }
 }

--- a/src/Laravel5_Api/Exceptions/Unauthorized.php
+++ b/src/Laravel5_Api/Exceptions/Unauthorized.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SehrGut\Laravel5_Api\Exceptions;
+
+use SehrGut\Laravel5_Api\Exceptions\Exception as BaseException;
+
+class Unauthorized extends BaseException
+{
+    protected $message = 'Not authorized!';
+    protected $status = 403;
+}

--- a/src/Laravel5_Api/Plugins/Authorization.php
+++ b/src/Laravel5_Api/Plugins/Authorization.php
@@ -5,7 +5,6 @@ namespace SehrGut\Laravel5_Api\Plugins;
 use Illuminate\Foundation\Auth\User as DummyUser;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
-
 use SehrGut\Laravel5_Api\Exceptions\Unauthorized;
 use SehrGut\Laravel5_Api\Hooks\AuthorizeAction;
 use SehrGut\Laravel5_Api\Hooks\AuthorizeResource;
@@ -21,6 +20,7 @@ class Authorization extends Plugin implements AuthorizeAction, AuthorizeResource
         if ($this->authenticatedUserOrDummy()->cant($action, $this->controller->getModelNameWithNamespace())) {
             throw new Unauthorized();
         }
+
         return $action;
     }
 
@@ -30,6 +30,7 @@ class Authorization extends Plugin implements AuthorizeAction, AuthorizeResource
         if (Gate::forUser($this->authenticatedUserOrDummy())->denies($action, $this->controller->resource)) {
             throw new Unauthorized();
         }
+
         return $action;
     }
 

--- a/src/Laravel5_Api/Plugins/Authorization.php
+++ b/src/Laravel5_Api/Plugins/Authorization.php
@@ -36,9 +36,11 @@ class Authorization extends Plugin implements AuthorizeAction, AuthorizeResource
 
     /**
      * Laravel assumes an authenticated User object for any authorization.
-     * There might be situations where you don't have or need an User in your authorisation logic.
-     * For those situations we will simply create a DummyUser which contains no information
-     * in order to satisfy Laravel's authorisation logic.
+     *
+     * There might be situations where you don't have or need an User in
+     * your authorisation logic. For those situations we will simply
+     * create a DummyUser which contains no information in order
+     * to satisfy Laravel's authorisation logic.
      *
      * @return Illuminate\Foundation\Auth\User
      */

--- a/src/Laravel5_Api/Plugins/Authorization.php
+++ b/src/Laravel5_Api/Plugins/Authorization.php
@@ -17,7 +17,7 @@ class Authorization extends Plugin implements AuthorizeAction, AuthorizeResource
     /** {@inheritdoc} */
     public function authorizeAction(String $action)
     {
-        if ($this->authenticatedUserOrDummy()->cant($action, $this->controller->getModelNameWithNamespace())) {
+        if (Gate::forUser($this->authenticatedUserOrDummy())->denies($action, $this->controller->getModelNameWithNamespace())) {
             throw new Unauthorized();
         }
 

--- a/src/Laravel5_Api/Plugins/Authorization.php
+++ b/src/Laravel5_Api/Plugins/Authorization.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SehrGut\Laravel5_Api\Plugins;
+
+use Illuminate\Foundation\Auth\User as DummyUser;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+
+use SehrGut\Laravel5_Api\Exceptions\Unauthorized;
+use SehrGut\Laravel5_Api\Hooks\AuthorizeAction;
+use SehrGut\Laravel5_Api\Hooks\AuthorizeResource;
+
+/**
+ * This plugin checks for Policies or Gate Closures for an action or a single resource.
+ */
+class Authorization extends Plugin implements AuthorizeAction, AuthorizeResource
+{
+    /** {@inheritdoc} */
+    public function authorizeAction(String $action)
+    {
+        if ($this->authenticatedUserOrDummy()->cant($action, $this->controller->getModelNameWithNamespace())) {
+            throw new Unauthorized();
+        }
+        return $action;
+    }
+
+    /** {@inheritdoc} */
+    public function authorizeResource(String $action)
+    {
+        if (Gate::forUser($this->authenticatedUserOrDummy())->denies($action, $this->controller->resource)) {
+            throw new Unauthorized();
+        }
+        return $action;
+    }
+
+    /**
+     * Laravel assumes an authenticated User object for any authorization.
+     * There might be situations where you don't have or need an User in your authorisation logic.
+     * For those situations we will simply create a DummyUser which contains no information
+     * in order to satisfy Laravel's authorisation logic.
+     *
+     * @return Illuminate\Foundation\Auth\User
+     */
+    protected function authenticatedUserOrDummy()
+    {
+        return Auth::user() ?: new DummyUser();
+    }
+}

--- a/tests/Controllers/AuthorizedController.php
+++ b/tests/Controllers/AuthorizedController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Controllers;
+
+use SehrGut\Laravel5_Api\Controller;
+use SehrGut\Laravel5_Api\Plugins\Authorization;
+use Tests\Models\Post;
+
+class AuthorizedController extends Controller
+{
+    protected $model = Post::class;
+
+    protected $plugins = [
+        Authorization::class,
+    ];
+}

--- a/tests/Migrations/CreateUsersTable.php
+++ b/tests/Migrations/CreateUsersTable.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+}

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    protected $fillable = ['name', 'email'];
+}

--- a/tests/PluginTests/AuthorizationPluginTest.php
+++ b/tests/PluginTests/AuthorizationPluginTest.php
@@ -57,7 +57,9 @@ class AuthorizationPluginTest extends TestCase
     public function test_index_action_with_user()
     {
         $db_user = User::create(['email' => 'test@example.org']);
-        Gate::define('index', function($user, $post) use ($db_user) { return $user == $db_user; });
+        Gate::define('index', function ($user, $post) use ($db_user) {
+            return $user == $db_user;
+        });
 
         $response = $this->get('/posts');
         $this->assertTrue($response->exception instanceof Unauthorized);
@@ -69,7 +71,9 @@ class AuthorizationPluginTest extends TestCase
     public function test_store_action_with_user()
     {
         $db_user = User::create(['email' => 'test@example.org']);
-        Gate::define('store', function($user, $post) use ($db_user) { return $user == $db_user; });
+        Gate::define('store', function ($user, $post) use ($db_user) {
+            return $user == $db_user;
+        });
 
         $response = $this->post('/posts', ['title' => 'Test Post', 'slug' => 'test-post']);
         $this->assertTrue($response->exception instanceof Unauthorized);
@@ -82,7 +86,9 @@ class AuthorizationPluginTest extends TestCase
     {
         $db_user = User::create(['email' => 'test@example.org']);
         Post::create(['title' => 'Test Post', 'slug' => 'test-post']);
-        Gate::define('show', function($user, $post) use ($db_user) { return $user == $db_user; });
+        Gate::define('show', function ($user, $post) use ($db_user) {
+            return $user == $db_user;
+        });
 
         $response = $this->get('/posts/1');
         $this->assertTrue($response->exception instanceof Unauthorized);
@@ -95,7 +101,9 @@ class AuthorizationPluginTest extends TestCase
     {
         $db_user = User::create(['email' => 'test@example.org']);
         Post::create(['title' => 'Test Post', 'slug' => 'test-post']);
-        Gate::define('update', function($user, $post) use ($db_user) { return $user == $db_user; });
+        Gate::define('update', function ($user, $post) use ($db_user) {
+            return $user == $db_user;
+        });
 
         $response = $this->put('/posts/1', ['title' => 'New Title']);
         $this->assertTrue($response->exception instanceof Unauthorized);
@@ -108,7 +116,9 @@ class AuthorizationPluginTest extends TestCase
     {
         $db_user = User::create(['email' => 'test@example.org']);
         Post::create(['title' => 'Test Post', 'slug' => 'test-post']);
-        Gate::define('destroy', function($user, $post) use ($db_user) { return $user == $db_user; });
+        Gate::define('destroy', function ($user, $post) use ($db_user) {
+            return $user == $db_user;
+        });
 
         $response = $this->delete('/posts/1');
         $this->assertTrue($response->exception instanceof Unauthorized);

--- a/tests/PluginTests/AuthorizationPluginTest.php
+++ b/tests/PluginTests/AuthorizationPluginTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\PluginTests;
+
+use Illuminate\Support\Facades\Gate;
+use SehrGut\Laravel5_Api\Exceptions\Unauthorized;
+use Tests\Models\Post;
+use Tests\Models\User;
+use Tests\TestCase;
+
+class AuthorizationPluginTest extends TestCase
+{
+    /** {@inheritdoc} */
+    public static $controller = \Tests\Controllers\AuthorizedController::class;
+
+    public function test_it_denies_anonymous_access()
+    {
+        Post::create(['title' => 'Test Post', 'slug' => 'test-post']);
+
+        $response = $this->get('/posts');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $response = $this->post('/posts');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $response = $this->get('/posts/1');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $response = $this->put('/posts/1', ['title' => 'New Title']);
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $response = $this->delete('/posts/1');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+    }
+
+    public function test_it_denies_access_when_no_rules_defined()
+    {
+        $user = User::create(['email' => 'test@example.org']);
+        Post::create(['title' => 'Test Post', 'slug' => 'test-post']);
+
+        $response = $this->actingAs($user)->get('/posts');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $response = $this->actingAs($user)->post('/posts');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $response = $this->actingAs($user)->get('/posts/1');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $response = $this->actingAs($user)->put('/posts/1', ['title' => 'New Title']);
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $response = $this->actingAs($user)->delete('/posts/1');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+    }
+
+    public function test_index_action_with_user()
+    {
+        $db_user = User::create(['email' => 'test@example.org']);
+        Gate::define('index', function($user, $post) use ($db_user) { return $user == $db_user; });
+
+        $response = $this->get('/posts');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $this->actingAs($db_user)->get('/posts')
+            ->assertStatus(200);
+    }
+
+    public function test_store_action_with_user()
+    {
+        $db_user = User::create(['email' => 'test@example.org']);
+        Gate::define('store', function($user, $post) use ($db_user) { return $user == $db_user; });
+
+        $response = $this->post('/posts', ['title' => 'Test Post', 'slug' => 'test-post']);
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $this->actingAs($db_user)->post('/posts', ['title' => 'Test Post', 'slug' => 'test-post'])
+            ->assertStatus(200);
+    }
+
+    public function test_show_action_with_user()
+    {
+        $db_user = User::create(['email' => 'test@example.org']);
+        Post::create(['title' => 'Test Post', 'slug' => 'test-post']);
+        Gate::define('show', function($user, $post) use ($db_user) { return $user == $db_user; });
+
+        $response = $this->get('/posts/1');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $this->actingAs($db_user)->get('/posts/1')
+            ->assertStatus(200);
+    }
+
+    public function test_update_action_with_user()
+    {
+        $db_user = User::create(['email' => 'test@example.org']);
+        Post::create(['title' => 'Test Post', 'slug' => 'test-post']);
+        Gate::define('update', function($user, $post) use ($db_user) { return $user == $db_user; });
+
+        $response = $this->put('/posts/1', ['title' => 'New Title']);
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $this->actingAs($db_user)->put('/posts/1', ['title' => 'New Title'])
+            ->assertStatus(200);
+    }
+
+    public function test_destroy_action_with_user()
+    {
+        $db_user = User::create(['email' => 'test@example.org']);
+        Post::create(['title' => 'Test Post', 'slug' => 'test-post']);
+        Gate::define('destroy', function($user, $post) use ($db_user) { return $user == $db_user; });
+
+        $response = $this->delete('/posts/1');
+        $this->assertTrue($response->exception instanceof Unauthorized);
+
+        $this->actingAs($db_user)->delete('/posts/1')
+            ->assertStatus(204);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,8 +4,6 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\Route;
-use Tests\Migrations\CreateCommentsTable;
-use Tests\Migrations\CreatePostsTable;
 
 class TestCase extends BaseTestCase
 {
@@ -37,25 +35,26 @@ class TestCase extends BaseTestCase
     public function setUp()
     {
         parent::setUp();
-
-        $this->app['config']->set('database.default', 'sqlite');
-        $this->app['config']->set('database.connections.sqlite.database', ':memory:');
-
-        $this->migrate();
+        $this->setupDatabase();
         $this->registerRoutes();
     }
 
     /**
-     * Run test migrations.
+     * Configure the DB and run test migrations.
      *
      * @return void
      */
-    protected function migrate()
+    protected function setupDatabase()
     {
+        $this->app['config']->set('database.default', 'sqlite');
+        $this->app['config']->set('database.connections.sqlite.database', ':memory:');
+
         $migrations = [
-            CreatePostsTable::class,
-            CreateCommentsTable::class,
+            \Tests\Migrations\CreateUsersTable::class,
+            \Tests\Migrations\CreatePostsTable::class,
+            \Tests\Migrations\CreateCommentsTable::class,
         ];
+
         foreach ($migrations as $class) {
             (new $class())->up();
         }


### PR DESCRIPTION
I removed `AuthorizeAction` calls for single resource methods such as `show()` which also have a `AuthorizeResource` call. Otherwise there would be problems with Policy definitions for methods like `index()` which don't have a single resource but would have to because the policy would be called two times. Please give me feedback if this makes sense to you.

For the moment if you add the Authorization plugin to your controller every method that doesn't have a policy defined will throw an Unauthorized Exception. This means if you use the plugin and you have methods that should be accessible to anyone without authorization you must define policy methods for these which simply `return true`. Is this our desired behavior?